### PR TITLE
Add Gem Version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gem Version](https://badge.fury.io/rb/quadrigacx.svg)](https://badge.fury.io/rb/quadrigacx)
+
 # Quadrigacx
 
 Ruby wrapper for the QuadrigaCX API.


### PR DESCRIPTION
Is generally a common practice for ruby gems to have this badge on the README to indicate the latest version.