### PR TITLE
Fix 13 - Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+
+notifications:
+  email: false
+
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/quadrigacx.svg)](https://badge.fury.io/rb/quadrigacx)
+[![Build Status](https://travis-ci.org/mhluska/quadrigacx.svg?branch=master)](https://travis-ci.org/mhluska/quadrigacx)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f0ec6c87254b1cfafe46/maintainability)](https://codeclimate.com/github/mhluska/quadrigacx/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f0ec6c87254b1cfafe46/test_coverage)](https://codeclimate.com/github/mhluska/quadrigacx/test_coverage)
 

--- a/quadrigacx.gemspec
+++ b/quadrigacx.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_runtime_dependency 'json',        '~> 1.8'
   spec.add_runtime_dependency 'rest-client', '~> 1.7'

--- a/quadrigacx.gemspec
+++ b/quadrigacx.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'json',        '~> 1.8'
-  spec.add_runtime_dependency 'rest-client', '~> 1.7'
+  spec.add_runtime_dependency 'rest-client', '~> 2.0.2'
 
   spec.add_development_dependency 'byebug',      '~> 5.0'
   spec.add_development_dependency 'rspec',       '~> 3.1'
-  spec.add_development_dependency 'webmock',     '~> 1.20'
+  spec.add_development_dependency 'webmock',     '~> 3.2.0'
   spec.add_development_dependency 'vcr',         '~> 2.9'
   spec.add_development_dependency 'gem-release', '~> 0.7'
   spec.add_development_dependency 'bundler',     '~> 1.7'

--- a/quadrigacx.gemspec
+++ b/quadrigacx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'json',        '~> 1.8'
   spec.add_runtime_dependency 'rest-client', '~> 1.7'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'webmock/rspec'
 require 'vcr'
 require 'quadrigacx'
 


### PR DESCRIPTION
Adding config for Travis CI.

Adding a `required_ruby_version`, just as a good practice on the gem. I've put it to 2.x just to be safe.

Adding the build status badge.