### PR TITLE
Fix #18 - Add bitcoin gold/cash support for withdraw/deposit_address

### DIFF
--- a/lib/quadrigacx/coin.rb
+++ b/lib/quadrigacx/coin.rb
@@ -1,6 +1,8 @@
 module QuadrigaCX
   module Coin
     BITCOIN = 'bitcoin'
+    BITCOIN_CASH = 'bitcoincash'
+    BITCOIN_GOLD = 'bitcoingold'
     LITECOIN = 'litecoin'
     ETHER = 'ether'
 
@@ -12,6 +14,8 @@ module QuadrigaCX
 
     ALL_COINS = [
       BITCOIN,
+      BITCOIN_CASH,
+      BITCOIN_GOLD,
       LITECOIN,
       ETHER
     ]


### PR DESCRIPTION
Add the new coin types for _Bitcoin Gold_ and _Bitcoin Cash_.

This works with the recent #17 `coin` types.

This allows these coin types to be used for the `withdraw` and `deposit_address` methods.