### PR TITLE
make cancel order and lookup order take the order id directly

### DIFF
--- a/lib/quadrigacx/client/private.rb
+++ b/lib/quadrigacx/client/private.rb
@@ -45,8 +45,8 @@ module QuadrigaCX
     # Cancel an order.
     #
     # id – a 64 characters long hexadecimal string taken from the list of orders.
-    def cancel_order params={}
-      request(:post, '/cancel_order', params)
+    def cancel_order order_id
+      request(:post, '/cancel_order', id: order_id)
     end
 
     # Return a JSON list of open orders.
@@ -59,8 +59,8 @@ module QuadrigaCX
     # Returns JSON list of details about 1 or more orders.
     #
     # id – a single or array of 64 characters long hexadecimal string taken from the list of orders.
-    def lookup_order params={}
-      request(:post, '/lookup_order', params)
+    def lookup_order order_id
+      request(:post, '/lookup_order', id: order_id)
     end
 
     # Withdrawal of the specified coin type.

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -37,7 +37,7 @@ describe QuadrigaCX::Client, :vcr do
 
       context 'when using the group option' do
         let!(:order) { safe_limit_buy }
-        after { subject.cancel_order(id: order.id) }
+        after { subject.cancel_order(order.id) }
 
         it 'does not group same price orders' do
           ungrouped_bids = subject.order_book(group: 0).bids
@@ -161,7 +161,7 @@ describe QuadrigaCX::Client, :vcr do
       let(:order) { safe_limit_buy }
 
       it 'cancels an order' do
-        response = subject.cancel_order(id: order.id)
+        response = subject.cancel_order(order.id)
         expect(response).to be true
       end
     end
@@ -171,7 +171,7 @@ describe QuadrigaCX::Client, :vcr do
       let(:open_orders_usd) { subject.open_orders(book: :btc_usd) }
       let!(:orders) { [safe_limit_buy, safe_limit_buy(book: :btc_usd)] }
 
-      after { orders.each { |order| subject.cancel_order(id: order.id) }}
+      after { orders.each { |order| subject.cancel_order(order.id) }}
 
       it 'lists open orders' do
         expect(open_orders_cad.first.datetime).not_to be_nil
@@ -185,7 +185,7 @@ describe QuadrigaCX::Client, :vcr do
     end
 
     describe '#lookup_order' do
-      let(:lookup_order) { subject.lookup_order(id: '1na3tujn948erx1xlbfu8yw93f8y41vgja5if6zdegvwk8pcked34l48sh1or189') }
+      let(:lookup_order) { subject.lookup_order('1na3tujn948erx1xlbfu8yw93f8y41vgja5if6zdegvwk8pcked34l48sh1or189') }
 
       it 'looks up an order' do
         expect(lookup_order.first.amount).to_not be_nil


### PR DESCRIPTION
the readme actually had examples with order id passed directly already

@mhluska @kevinjalbert I noticed the readme error and decided to make this PR with cancel and lookup taking one param (the order id) instead of fixing the readme, as it seemed to make some sense rather than passing id: ... every time.  If you prefer sticking to the id: ... style I can fix the readme instead, just let me know.