### PR TITLE
Fix #21 - Add SimpleCov and hook it up to CodeClimate for Test Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,13 @@ rvm:
 notifications:
   email: false
 
-script: bundle exec rspec
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+script:
+  - bundle exec rspec
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/quadrigacx.gemspec
+++ b/quadrigacx.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'byebug',      '~> 5.0'
   spec.add_development_dependency 'rspec',       '~> 3.1'
+  spec.add_development_dependency 'simplecov',   '~> 0.16'
   spec.add_development_dependency 'webmock',     '~> 3.2.0'
   spec.add_development_dependency 'vcr',         '~> 2.9'
   spec.add_development_dependency 'gem-release', '~> 0.7'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'webmock/rspec'
 require 'vcr'
 require 'quadrigacx'


### PR DESCRIPTION
The CC_TEST_REPORTER_ID is set as an env var in travis ci.